### PR TITLE
Add option to color code output.

### DIFF
--- a/catest
+++ b/catest
@@ -27,6 +27,7 @@ cat_tstdir="test"			# test directory
 #
 cat_tests=""				# list of tests (absolute paths)
 opt_a=false				# run all tests
+opt_c=false				# colorize test results
 opt_k=false				# keep output of successful tests
 opt_o="/var/tmp"			# parent directory for output directory
 opt_t=					# TAP format output file
@@ -67,8 +68,8 @@ function usage
 	[[ $# -ne 0 ]] && echo "$cat_arg0: $@\n" >&2
 
 	cat <<USAGE >&2
-Usage: $cat_arg0 [-k] [-o dir] [-t file] test1 ...
-       $cat_arg0 [-k] [-o dir] [-t file] -a
+Usage: $cat_arg0 [-k] [-c] [-o dir] [-t file] test1 ...
+       $cat_arg0 [-k] [-c] [-o dir] [-t file] -a
 
 In the first form, runs specified tests.  In the second form, runs all tests
 found under "$cat_tstdir" of the form "tst*.<ext>" for supported extensions.
@@ -106,6 +107,7 @@ The following options may be specified:
 
 	-a 		Runs all tests under $cat_tstdir
 			(ignores other non-option arguments)
+	-c		Color code test result messages
 	-h		Output this message
 	-k		Keep output from all tests, not just failures
 	-o directory	Specifies the output directory for tests
@@ -166,7 +168,7 @@ function emit_failure
 		echo "not ok $(($cat_nrun+1)) $test_label" >> $cat_tapfile
 	fi
 
-	echo "FAILED."
+	echo "${TRED}FAILED.${TCLEAR}"
 	echo "$test_path failed: $reason" > "$odir/README"
 
 	[[ -n "$odir" ]] && echo ">>> failure details in $odir\n"
@@ -184,7 +186,7 @@ function emit_pass
 		echo "ok $((cat_nrun+1)) $test_label" >> $cat_tapfile
 	fi
 
-	echo "success."
+	echo "${TGREEN}success.${TCLEAR}"
 	((cat_npassed++))
 }
 
@@ -249,15 +251,25 @@ function execute_test
 	emit_pass "$test_label"
 }
 
-while getopts ":o:t:akSh?" c $@; do
+while getopts ":o:t:ackSh?" c $@; do
 	case "$c" in
-	a|k|S) 	eval opt_$c=true ;;
+	a|c|k|S) 	eval opt_$c=true ;;
 	o|t) 	eval opt_$c="$OPTARG" ;;
 	h)	usage ;;
 	:) 	usage "option requires an argument -- $OPTARG" ;;
 	*) 	usage "invalid option: $OPTARG" ;;
 	esac
 done
+
+#
+# Term colors
+#
+if [[ $opt_c == "true" && -t 1 ]]
+then
+    TGREEN=$(tput setaf 2)
+    TRED=$(tput setaf 1)
+    TCLEAR=$(tput sgr0)
+fi
 
 shift $((OPTIND-1))
 [[ $# -eq 0 && $opt_a == "false" ]] && \


### PR DESCRIPTION
Color code `success` green and `FAILURE` red in output, if supported by the current `TERM`.

Color defaults to off, use `-c` to enable.
